### PR TITLE
Replace fit('max') with a modified sizes array

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -94,6 +94,11 @@ function useSrcSet({ config, image, adjustImage }) {
 
   return React.useMemo(
     () => {
+      const [maxSize] = SIZES.slice(-1)
+      const sizes = SIZES.slice(0, -1)
+        .filter(w => w < image.asset.metadata.dimensions.width)
+        .concat(Math.min(image.asset.metadata.dimensions.width, maxSize))
+
       const thumb = {
         src: (
           image.asset.metadata.lqip ??
@@ -102,8 +107,8 @@ function useSrcSet({ config, image, adjustImage }) {
         width: 1
       }
 
-      const baseImage = builder.image(image).quality(80).auto('format').fit('max')
-      const sources = SIZES.map(width => ({ src: adjustImageRef.current(baseImage, width).url(), width }))
+      const baseImage = builder.image(image).quality(80).auto('format')
+      const sources = sizes.map(width => ({ src: adjustImageRef.current(baseImage, width).url(), width }))
 
       const src = sources.slice(-1)[0].src
       const srcSet = [thumb, ...sources].map(x => `${x.src} ${x.width}w`).join(',')


### PR DESCRIPTION
This is done to avoid a change of behavior in cropping: it wouldn't crop when your image was too small. Now, it always crops, but the actual size of the uploaded image is used as the maximum width of the srcSet. 

E.g: when uploading an image of 1200x1200 and attempting to make a 3:2 crop, you no longer get a 1200x1200 image as largest in the srcSet, but a 1200x800 (as you would expect).