### PR TITLE
Asset can be null

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -68,8 +68,8 @@ function ImageBase({
   imgProps = {}, 
   layoutClassName = undefined 
 }) {
-  if (process.env.NODE_ENV !== 'production' && !image.asset.metadata) {
-    console.error('Image asset doesn\'t have associated metadata. Did you forget to dereference the asset field (`image{..., asset->}`)?')
+  if (image?.asset && !image.asset.metadata) {
+    throw new Error('Image asset doesn\'t have associated metadata. Did you forget to dereference the asset field (`image{..., asset->}`)?')
   }
 
   const { ref: sizeRef, size: displaySize } = useElementSize()

--- a/src/Image.js
+++ b/src/Image.js
@@ -77,7 +77,7 @@ function ImageBase({
   const { width, height, size } = useDerivedSizes({
     deriveSizes, 
     displaySize,
-    naturalSize: image.asset.metadata.dimensions  
+    naturalSize: image.asset?.metadata.dimensions ?? { width: 0, height: 0 }
   })
 
   return (
@@ -98,6 +98,11 @@ function useSrcSet({ config, image, adjustImage }) {
 
   return React.useMemo(
     () => {
+      if (!image.asset) {
+        if (process.env.NODE_ENV !== 'production') console.warn('Image doesn\'t have associated asset object. This will render an <img /> tag with an empty src attribute.')
+        return { src: '', srcSet: '' }
+      }
+
       const [maxSize] = SIZES.slice(-1)
       const sizes = SIZES.slice(0, -1)
         .filter(w => w < image.asset.metadata.dimensions.width)

--- a/src/Image.js
+++ b/src/Image.js
@@ -75,9 +75,9 @@ function ImageBase({
   const { ref: sizeRef, size: displaySize } = useElementSize()
   const { src, srcSet } = useSrcSet({ config: sanityConfig, image, adjustImage })
   const { width, height, size } = useDerivedSizes({
-    deriveSizes, 
+    deriveSizes,
     displaySize,
-    naturalSize: image.asset?.metadata.dimensions ?? { width: 0, height: 0 }
+    naturalSize: image.asset.metadata.dimensions ?? { width: 0, height: 0 }
   })
 
   return (


### PR DESCRIPTION
After some delibiration, I'm convinced a missing asset in an image object should render a broken img, just like omitting a src tag from an image would. 

A slightly related change: not dereferencing an asset field, should actually thrown an error instead of just logging an error to the console. This will help track this error down, should it pop up in Rollbar.