### PR TITLE
Fix aspect ratio of initial image thumb

### DIFF
--- a/src/Image.js
+++ b/src/Image.js
@@ -104,10 +104,7 @@ function useSrcSet({ config, image, adjustImage }) {
         .concat(Math.min(image.asset.metadata.dimensions.width, maxSize))
 
       const thumb = {
-        src: (
-          image.asset.metadata.lqip ??
-          builder.image(image).width(20).quality(0).blur(20).auto('format').url()
-        ),
+        src: adjustImageRef.current(builder.image(image).quality(0).blur(20).auto('format'), 20).url(),
         width: 1
       }
 


### PR DESCRIPTION
The default lqip base64 placeholder that's present in the image object, doesn't have the correct aspect ratio, causing the thumbnail to be displayed in incorrect dimensions in some cases. This fixes this, by generating the thumbnail ourselves.