### PR TITLE
Allow a sizes attribute to be given, overwriting the calculated image…

### DIFF
--- a/example/package.json
+++ b/example/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "license": "MIT",
   "dependencies": {
-    "@kaliber/build": "^0.0.116",
+    "@kaliber/build": "^0.0.123",
     "@kaliber/use-element-size": "^3.0.0",
     "@sanity/image-url": "^1.0.1"
   },

--- a/example/src/App.css
+++ b/example/src/App.css
@@ -1,19 +1,24 @@
-.component {
-  position: absolute;
-  margin: 20px;
+.layout {
+  & > .imageCover {
+    height: 50vh !important;
+    width: 100% !important;
+  }
+
+  & > .imageCropped1To1 {
+    width: 100%;
+    max-width: 1024px !important;
+  }
+
+  & > .imageCropped1To2 {
+    width: 100%;
+    max-width: 720px !important;
+  }
+
+  & > .imageSmall {
+    width: 200px;
+  }
 }
 
-.imageCover {
-  height: 50vh !important;
-  width: 100% !important;
-}
-
-.imageCropped1To1 {
-  width: 100%;
-  max-width: 1024px !important;
-}
-
-.imageCropped1To2 {
-  width: 100%;
-  max-width: 720px !important;
+.imageInline {
+  display: inline-block;
 }

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -10,6 +10,10 @@ export default function App({ config }) {
       <AppSection title='Regular image'>
         <Image sanityConfig={config.sanity} {...{ image }} />
       </AppSection>  
+      
+      <AppSection title='Image with sizes attribute'>
+        <ImageCropped sanityConfig={config.sanity} aspectRatio={2 / 1} sizes='(min-width: 760px) 720px, calc(100vw - 40px)' {...{ image }} />
+      </AppSection>  
 
       <AppSection title='Cropped image (16/9)'>
         <ImageCropped sanityConfig={config.sanity} aspectRatio={16 / 9} {...{ image }} />

--- a/example/src/App.js
+++ b/example/src/App.js
@@ -10,6 +10,14 @@ export default function App({ config }) {
       <AppSection title='Regular image'>
         <Image sanityConfig={config.sanity} {...{ image }} />
       </AppSection>  
+
+      <AppSection title='Inline image'>
+        <div className={styles.layout}>
+          Lorem, ipsum dolor sit amet consectetur adipisicing elit. Assumenda, quod?
+          <Image sanityConfig={config.sanity} {...{ image }} layoutClassName={styles.imageSmall} imgProps={{ className: styles.imageInline }} />
+          Laboriosam molestias eveniet recusandae nostrum aperiam maxime aliquid maiores vero eos amet dolorem eius eligendi excepturi, voluptatem sint illum distinctio?
+        </div>
+      </AppSection>  
       
       <AppSection title='Image with sizes attribute'>
         <ImageCropped sanityConfig={config.sanity} aspectRatio={2 / 1} sizes='(min-width: 760px) 720px, calc(100vw - 40px)' {...{ image }} />
@@ -20,15 +28,21 @@ export default function App({ config }) {
       </AppSection>  
 
       <AppSection title='Cropped image (1/1)'>
-        <ImageCropped sanityConfig={config.sanity} aspectRatio={1 / 1} {...{ image }} layoutClassName={styles.imageCropped1To1} />
+        <div className={styles.layout}>
+          <ImageCropped sanityConfig={config.sanity} aspectRatio={1 / 1} {...{ image }} layoutClassName={styles.imageCropped1To1} />
+        </div>
       </AppSection>  
 
       <AppSection title='Cropped image (1/2)'>
-        <ImageCropped sanityConfig={config.sanity} aspectRatio={1 / 2} {...{ image }} layoutClassName={styles.imageCropped1To2} />
+        <div className={styles.layout}>
+          <ImageCropped sanityConfig={config.sanity} aspectRatio={1 / 2} {...{ image }} layoutClassName={styles.imageCropped1To2} />
+        </div>
       </AppSection>  
 
       <AppSection title='Image with object-fit'>
-        <ImageCover sanityConfig={config.sanity} aspectRatio={16 / 9} {...{ image }} layoutClassName={styles.imageCover} />
+        <div className={styles.layout}>
+          <ImageCover sanityConfig={config.sanity} aspectRatio={16 / 9} {...{ image }} layoutClassName={styles.imageCover} />
+        </div>
       </AppSection>  
     </main>
   )

--- a/example/yarn.lock
+++ b/example/yarn.lock
@@ -71,6 +71,15 @@
     semver "^6.3.0"
     source-map "^0.5.0"
 
+"@babel/eslint-parser@^7.16.5":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/eslint-parser/-/eslint-parser-7.17.0.tgz#eabb24ad9f0afa80e5849f8240d0e5facc2d90d6"
+  integrity sha512-PUEJ7ZBXbRkbq3qqM/jZ2nIuakUBqCYc7Qf52Lj7dlZ6zERnqisdHioL0l4wwQZnmskMeasqUNzLBFKs3nylXA==
+  dependencies:
+    eslint-scope "^5.1.1"
+    eslint-visitor-keys "^2.1.0"
+    semver "^6.3.0"
+
 "@babel/generator@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.11.0.tgz#4b90c78d8c12825024568cbe83ee6c9af193585c"
@@ -102,6 +111,13 @@
   integrity sha512-ItmYF9vR4zA8cByDocY05o0LGUkp1zhbTQOH1NFyl5xXEqlTJQCEJjieriw+aFpxo16swMxUnUiKS7a/r4vtHg==
   dependencies:
     "@babel/types" "^7.16.0"
+
+"@babel/helper-annotate-as-pure@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.16.7.tgz#bb2339a7534a9c128e3102024c60760a3a7f3862"
+  integrity sha512-s6t2w/IPQVTAET1HitoowRGXooX8mCgtuP5195wD/QJPV6wYjpujCGF7JuMODVX2ZAJOf1GT6DT9MHEZvLOFSw==
+  dependencies:
+    "@babel/types" "^7.16.7"
 
 "@babel/helper-builder-binary-assignment-operator-visitor@^7.16.0":
   version "7.16.0"
@@ -250,6 +266,13 @@
   dependencies:
     "@babel/types" "^7.16.0"
 
+"@babel/helper-module-imports@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz#25612a8091a999704461c8a222d0efec5d091437"
+  integrity sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==
+  dependencies:
+    "@babel/types" "^7.16.7"
+
 "@babel/helper-module-transforms@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.11.0.tgz#b16f250229e47211abdd84b34b64737c2ab2d359"
@@ -300,6 +323,11 @@
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
   integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
+
+"@babel/helper-plugin-utils@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz#aa3a8ab4c3cceff8e65eb9e73d87dc4ff320b2f5"
+  integrity sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA==
 
 "@babel/helper-regex@^7.10.4":
   version "7.10.5"
@@ -394,10 +422,20 @@
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.15.7.tgz#220df993bfe904a4a6b02ab4f3385a5ebf6e2389"
   integrity sha512-K4JvCtQqad9OY2+yTU8w+E82ywk/fe+ELNlt1G8z3bVGlZfn/hOcQQsUhGhW/N+tb3fxK800wLtKOE/aM0m72w==
 
+"@babel/helper-validator-identifier@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz#e8c602438c4a8195751243da9031d1607d247cad"
+  integrity sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw==
+
 "@babel/helper-validator-option@^7.14.5":
   version "7.14.5"
   resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
   integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helper-validator-option@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz#b203ce62ce5fe153899b617c08957de860de4d23"
+  integrity sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ==
 
 "@babel/helper-wrap-function@^7.10.4":
   version "7.10.4"
@@ -455,7 +493,7 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.10.4", "@babel/parser@^7.11.0", "@babel/parser@^7.7.0":
+"@babel/parser@^7.10.4", "@babel/parser@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.11.0.tgz#a9d7e11aead25d3b422d17b2c6502c8dddef6a5d"
   integrity sha512-qvRvi4oI8xii8NllyEc4MDJjuZiNaRzyb7Y7lup1NqJV8TZHF4O27CcP+72WPn/k1zkgJ6WJfnIbk4jTsVAZHw==
@@ -692,12 +730,12 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/plugin-syntax-jsx@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.0.tgz#f9624394317365a9a88c82358d3f8471154698f1"
-  integrity sha512-8zv2+xiPHwly31RK4RmnEYY5zziuF3O7W2kIDW+07ewWDh6Oi0dRq8kwvulRkFgt6DB97RlKs5c1y068iPlCUg==
+"@babel/plugin-syntax-jsx@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz#50b6571d13f764266a113d77c82b4a6508bbe665"
+  integrity sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-syntax-logical-assignment-operators@^7.10.4":
   version "7.10.4"
@@ -963,38 +1001,38 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.14.5"
 
-"@babel/plugin-transform-react-display-name@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.0.tgz#9a0ad8aa8e8790883a7bd2736f66229a58125676"
-  integrity sha512-FJFdJAqaCpndL+pIf0aeD/qlQwT7QXOvR6Cc8JPvNhKJBi2zc/DPc4g05Y3fbD/0iWAMQFGij4+Xw+4L/BMpTg==
+"@babel/plugin-transform-react-display-name@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-display-name/-/plugin-transform-react-display-name-7.16.7.tgz#7b6d40d232f4c0f550ea348593db3b21e2404340"
+  integrity sha512-qgIg8BcZgd0G/Cz916D5+9kqX0c7nPZyXaP8R2tLNN5tkyIZdG5fEwBrxwplzSnjC1jvQmyMNVwUCZPcbGY7Pg==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
-"@babel/plugin-transform-react-jsx-development@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.0.tgz#1cb52874678d23ab11d0d16488d54730807303ef"
-  integrity sha512-qq65iSqBRq0Hr3wq57YG2AmW0H6wgTnIzpffTphrUWUgLCOK+zf1f7G0vuOiXrp7dU1qq+fQBoqZ3wCDAkhFzw==
+"@babel/plugin-transform-react-jsx-development@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.16.7.tgz#43a00724a3ed2557ed3f276a01a929e6686ac7b8"
+  integrity sha512-RMvQWvpla+xy6MlBpPlrKZCMRs2AGiHOGHY3xRwl0pEeim348dDyxeH4xBsMPbIMhujeq7ihE702eM2Ew0Wo+A==
   dependencies:
-    "@babel/plugin-transform-react-jsx" "^7.16.0"
+    "@babel/plugin-transform-react-jsx" "^7.16.7"
 
-"@babel/plugin-transform-react-jsx@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.16.0.tgz#55b797d4960c3de04e07ad1c0476e2bc6a4889f1"
-  integrity sha512-rqDgIbukZ44pqq7NIRPGPGNklshPkvlmvqjdx3OZcGPk4zGIenYkxDTvl3LsSL8gqcc3ZzGmXPE6hR/u/voNOw==
+"@babel/plugin-transform-react-jsx@^7.16.7":
+  version "7.17.3"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.17.3.tgz#eac1565da176ccb1a715dae0b4609858808008c1"
+  integrity sha512-9tjBm4O07f7mzKSIlEmPdiE6ub7kfIe6Cd+w+oQebpATfTQMAgW+YOuWxogbKVTulA+MEO7byMeIUtQ1z+z+ZQ==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-module-imports" "^7.16.0"
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/plugin-syntax-jsx" "^7.16.0"
-    "@babel/types" "^7.16.0"
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-module-imports" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/plugin-syntax-jsx" "^7.16.7"
+    "@babel/types" "^7.17.0"
 
-"@babel/plugin-transform-react-pure-annotations@^7.16.0":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.0.tgz#23db6ddf558d8abde41b8ad9d59f48ad5532ccab"
-  integrity sha512-NC/Bj2MG+t8Ef5Pdpo34Ay74X4Rt804h5y81PwOpfPtmAK3i6CizmQqwyBQzIepz1Yt8wNr2Z2L7Lu3qBMfZMA==
+"@babel/plugin-transform-react-pure-annotations@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-pure-annotations/-/plugin-transform-react-pure-annotations-7.16.7.tgz#232bfd2f12eb551d6d7d01d13fe3f86b45eb9c67"
+  integrity sha512-hs71ToC97k3QWxswh2ElzMFABXHvGiJ01IB1TbYQDGeWRKWz/MPUTh5jGExdHvosYKpnJW5Pm3S4+TA3FyX+GA==
   dependencies:
-    "@babel/helper-annotate-as-pure" "^7.16.0"
-    "@babel/helper-plugin-utils" "^7.14.5"
+    "@babel/helper-annotate-as-pure" "^7.16.7"
+    "@babel/helper-plugin-utils" "^7.16.7"
 
 "@babel/plugin-transform-regenerator@^7.16.0":
   version "7.16.0"
@@ -1164,17 +1202,17 @@
     "@babel/types" "^7.4.4"
     esutils "^2.0.2"
 
-"@babel/preset-react@^7.10.4":
-  version "7.16.0"
-  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.16.0.tgz#f71d3e8dff5218478011df037fad52660ee6d82a"
-  integrity sha512-d31IFW2bLRB28uL1WoElyro8RH5l6531XfxMtCeCmp6RVAF1uTfxxUA0LH1tXl+psZdwfmIbwoG4U5VwgbhtLw==
+"@babel/preset-react@^7.16.7":
+  version "7.16.7"
+  resolved "https://registry.yarnpkg.com/@babel/preset-react/-/preset-react-7.16.7.tgz#4c18150491edc69c183ff818f9f2aecbe5d93852"
+  integrity sha512-fWpyI8UM/HE6DfPBzD8LnhQ/OcH8AgTaqcqP2nGOXEUV+VKBR5JRN9hCk9ai+zQQ57vtm9oWeXguBCPNUjytgA==
   dependencies:
-    "@babel/helper-plugin-utils" "^7.14.5"
-    "@babel/helper-validator-option" "^7.14.5"
-    "@babel/plugin-transform-react-display-name" "^7.16.0"
-    "@babel/plugin-transform-react-jsx" "^7.16.0"
-    "@babel/plugin-transform-react-jsx-development" "^7.16.0"
-    "@babel/plugin-transform-react-pure-annotations" "^7.16.0"
+    "@babel/helper-plugin-utils" "^7.16.7"
+    "@babel/helper-validator-option" "^7.16.7"
+    "@babel/plugin-transform-react-display-name" "^7.16.7"
+    "@babel/plugin-transform-react-jsx" "^7.16.7"
+    "@babel/plugin-transform-react-jsx-development" "^7.16.7"
+    "@babel/plugin-transform-react-pure-annotations" "^7.16.7"
 
 "@babel/runtime-corejs3@^7.10.2":
   version "7.11.0"
@@ -1216,7 +1254,7 @@
     "@babel/parser" "^7.16.0"
     "@babel/types" "^7.16.0"
 
-"@babel/traverse@^7.10.4", "@babel/traverse@^7.11.0", "@babel/traverse@^7.7.0":
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.11.0":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.11.0.tgz#9b996ce1b98f53f7c3e4175115605d56ed07dd24"
   integrity sha512-ZB2V+LskoWKNpMq6E5UUCrjtDUh5IOTAyIl0dTjIEoXum/iKWkoIEKIRDnUucO6f+2FzNkE0oD4RLKoPIufDtg==
@@ -1246,7 +1284,7 @@
     debug "^4.1.0"
     globals "^11.1.0"
 
-"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.4.4", "@babel/types@^7.7.0":
+"@babel/types@^7.10.4", "@babel/types@^7.11.0", "@babel/types@^7.4.4":
   version "7.11.0"
   resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.11.0.tgz#2ae6bf1ba9ae8c3c43824e5861269871b206e90d"
   integrity sha512-O53yME4ZZI0jO1EVGtF1ePGl0LHirG4P1ibcD80XyzZcKhcMFeCXmh4Xb1ifGBIV233Qg12x4rBfQgA+tmOukA==
@@ -1261,6 +1299,14 @@
   integrity sha512-PJgg/k3SdLsGb3hhisFvtLOw5ts113klrpLuIPtCJIU+BB24fqq6lf8RWqKJEjzqXR9AEH1rIb5XTqwBHB+kQg==
   dependencies:
     "@babel/helper-validator-identifier" "^7.15.7"
+    to-fast-properties "^2.0.0"
+
+"@babel/types@^7.16.7", "@babel/types@^7.17.0":
+  version "7.17.0"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.17.0.tgz#a826e368bccb6b3d84acd76acad5c0d87342390b"
+  integrity sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==
+  dependencies:
+    "@babel/helper-validator-identifier" "^7.16.7"
     to-fast-properties "^2.0.0"
 
 "@csstools/convert-colors@^1.4.0":
@@ -1297,12 +1343,13 @@
   resolved "https://registry.yarnpkg.com/@humanwhocodes/object-schema/-/object-schema-1.2.1.tgz#b520529ec21d8e5945a1851dfd1c32e94e39ff45"
   integrity sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==
 
-"@kaliber/build@^0.0.116":
-  version "0.0.116"
-  resolved "https://registry.yarnpkg.com/@kaliber/build/-/build-0.0.116.tgz#62fde699b56967382b259b3043970a7643f501b7"
-  integrity sha512-BOPSkbZ9PVn00YbYAPYPpmUZSpkpm/dvfqXqyQA2WhJfMoyGZ6PZeSUTNgxllOqWqzXcHeMtDQnuDnSQDVnN0g==
+"@kaliber/build@^0.0.123":
+  version "0.0.123"
+  resolved "https://registry.yarnpkg.com/@kaliber/build/-/build-0.0.123.tgz#27658d4a4b05e18b37ccefd04bd523f89efa9e0f"
+  integrity sha512-WhaPbatU2A8rzEuTfG79wpP+rmz3NQVOKbeepFHezpDbtdNahenEScCGmY6l75skGsdj3K3TDt8T19hcoLmo4w==
   dependencies:
     "@babel/core" "^7.11.6"
+    "@babel/eslint-parser" "^7.16.5"
     "@babel/plugin-proposal-class-properties" "^7.10.4"
     "@babel/plugin-proposal-decorators" "^7.10.5"
     "@babel/plugin-proposal-object-rest-spread" "^7.11.0"
@@ -1311,12 +1358,11 @@
     "@babel/plugin-transform-async-to-generator" "^7.10.4"
     "@babel/plugin-transform-runtime" "^7.11.5"
     "@babel/preset-env" "^7.11.5"
-    "@babel/preset-react" "^7.10.4"
+    "@babel/preset-react" "^7.16.7"
     "@babel/runtime" "^7.11.2"
     "@kaliber/config" "^0.0.8"
     "@kaliber/eslint-plugin" "*"
     ansi-regex "^5.0.0"
-    babel-eslint "^10.1.0"
     babel-loader "^8.0.6"
     cache-loader "^4.1.0"
     classnames "^2.2.6"
@@ -1349,6 +1395,7 @@
     import-fresh "^3.2.1"
     json-loader "^0.5.7"
     loader-utils "^2.0.0"
+    morgan "^1.10.0"
     npm-run-all "^4.1.5"
     pkg-dir "^5.0.0"
     postcss "^7.0.34"
@@ -2030,18 +2077,6 @@ axobject-query@^2.1.2:
   resolved "https://registry.yarnpkg.com/axobject-query/-/axobject-query-2.2.0.tgz#943d47e10c0b704aa42275e20edf3722648989be"
   integrity sha512-Td525n+iPOOyUQIeBfcASuG6uJsDOITl7Mds5gFyerkWiX7qhUTdYUBlSgNMyVqtSJqwpt1kXGLdUt6SykLMRA==
 
-babel-eslint@^10.1.0:
-  version "10.1.0"
-  resolved "https://registry.yarnpkg.com/babel-eslint/-/babel-eslint-10.1.0.tgz#6968e568a910b78fb3779cdd8b6ac2f479943232"
-  integrity sha512-ifWaTHQ0ce+448CYop8AdrQiBsGrnC+bMgfyKFdi6EsPLTAWG+QfyDeM6OH+FmWnKvEq5NnBMLvlBUPKQZoDSg==
-  dependencies:
-    "@babel/code-frame" "^7.0.0"
-    "@babel/parser" "^7.7.0"
-    "@babel/traverse" "^7.7.0"
-    "@babel/types" "^7.7.0"
-    eslint-visitor-keys "^1.0.0"
-    resolve "^1.12.0"
-
 babel-loader@^8.0.6:
   version "8.1.0"
   resolved "https://registry.yarnpkg.com/babel-loader/-/babel-loader-8.1.0.tgz#c611d5112bd5209abe8b9fa84c3e4da25275f1c3"
@@ -2116,6 +2151,13 @@ base@^0.11.1:
     isobject "^3.0.1"
     mixin-deep "^1.2.0"
     pascalcase "^0.1.1"
+
+basic-auth@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/basic-auth/-/basic-auth-2.0.1.tgz#b998279bf47ce38344b4f3cf916d4679bbf51e3a"
+  integrity sha512-NF+epuEdnUYVlGuhaxbbq+dvJttwLnGY+YixlXlME5KpQ5W3CnXA5cVTneY3SPbPDRkcjMbifrwmFYcClgOZeg==
+  dependencies:
+    safe-buffer "5.1.2"
 
 big.js@^5.2.2:
   version "5.2.2"
@@ -3407,6 +3449,11 @@ depd@~1.1.2:
   resolved "https://registry.yarnpkg.com/depd/-/depd-1.1.2.tgz#9bcd52e14c097763e749b274c4346ed2e560b5a9"
   integrity sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
 
+depd@~2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/depd/-/depd-2.0.0.tgz#b696163cc757560d09cf22cc8fad1571b79e76df"
+  integrity sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==
+
 des.js@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/des.js/-/des.js-1.0.1.tgz#5382142e1bdc53f85d86d53e5f4aa7deb91e0843"
@@ -3878,12 +3925,12 @@ eslint-utils@^2.0.0, eslint-utils@^2.1.0:
   dependencies:
     eslint-visitor-keys "^1.1.0"
 
-eslint-visitor-keys@^1.0.0, eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
+eslint-visitor-keys@^1.1.0, eslint-visitor-keys@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
   integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
-eslint-visitor-keys@^2.0.0:
+eslint-visitor-keys@^2.0.0, eslint-visitor-keys@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-2.1.0.tgz#f65328259305927392c938ed44eb0a5c9b2bd303"
   integrity sha512-0rSmRBzXgDzIsD6mGdJgevzgezI534Cer5L/vyMX0kHzT/jiB43jRhd9YUlMGYLQy2zprNmoT8qasCGtY+QaKw==
@@ -6472,6 +6519,17 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
+morgan@^1.10.0:
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/morgan/-/morgan-1.10.0.tgz#091778abc1fc47cd3509824653dae1faab6b17d7"
+  integrity sha512-AbegBVI4sh6El+1gNwvD5YIck7nSA36weD7xvIxG4in80j/UoK8AEGaWnnz8v1GxonMCltmlNs5ZKbGvl9b1XQ==
+  dependencies:
+    basic-auth "~2.0.1"
+    debug "2.6.9"
+    depd "~2.0.0"
+    on-finished "~2.3.0"
+    on-headers "~1.0.2"
+
 move-concurrently@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/move-concurrently/-/move-concurrently-1.0.1.tgz#be2c005fda32e0b29af1f05d7c4b33214c701f92"
@@ -8480,7 +8538,7 @@ resolve-url@^0.2.1:
   resolved "https://registry.yarnpkg.com/resolve-url/-/resolve-url-0.2.1.tgz#2c637fe77c893afd2a663fe21aa9080068e2052a"
   integrity sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
 
-resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.12.0, resolve@^1.13.1, resolve@^1.3.2:
+resolve@^1.1.7, resolve@^1.10.0, resolve@^1.10.1, resolve@^1.13.1, resolve@^1.3.2:
   version "1.17.0"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
   integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaliber/sanity-image",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "index.js",
   "sideEffects": false,
   "publishConfig": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaliber/sanity-image",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "main": "index.js",
   "sideEffects": false,
   "publishConfig": {

--- a/readme.md
+++ b/readme.md
@@ -4,6 +4,8 @@ An image component for Sanity, which manages resizing, cropping, srcSet and size
 ## Motivation
 Sanity provides a lot of options when it comes to image optimization and this component tries to be the one size fits all solution, making sure you don't have to think about these. It also manages `srcSet` and `sizes` for you by looking at the actual displayed size of the image. This fits much better within a component driven model, where you never know in advance where your component is going to be used (and which `sizes` value you should therefore use).
 
+Even though the components work without a `sizes` prop, they *do* accept one. This allows the image to be displayed immediately, without your javascript bundle being parsed. Useful for images that are displayed above the fold, to reduce your LCP time. Think: hero images. 
+
 ## Installation
 
 Add the following libraries to your `compileWithBabel` array:
@@ -46,6 +48,8 @@ This library exports three components, `Image`, `ImageCropped` and `ImageCover`,
 - Use `Image` when you want to use an image as is, no cropping, no `object-fit: cover`.
 - Use `ImageCropped` when you want to use a cropped image. The crop is determined by the `aspectRatio` you provide (this respects the hotspot, when configured in Sanity).
 - Use `ImageCover` when you need an image that covers a size defined in CSS, but this size doesn't have a fixed aspect ratio. This component compensates for upscaling due to using `object-fit: cover`.
+
+All images accept a `sizes` prop. If this is given, any calculated size is ignored.
 
 #### `Image`
 ```jsx

--- a/src/Image.js
+++ b/src/Image.js
@@ -6,12 +6,13 @@ const SIZES = [320, 480, 720, 1024, 1440, 1920, 2400, 3000, 3600]
 export function Image({
   sanityConfig,
   image,
+  sizes = undefined,
   layoutClassName = undefined, 
   imgProps = {} 
 }) {
   return (
     <ImageBase  
-      {...{ sanityConfig, image, layoutClassName, imgProps }}
+      {...{ sanityConfig, image, sizes, layoutClassName, imgProps }}
       adjustImage={adjustImageWidth()}
       deriveSizes={deriveSizes()}
     />
@@ -22,13 +23,14 @@ export function ImageCropped({
   sanityConfig,
   image,
   aspectRatio,
+  sizes = undefined,
   layoutClassName = undefined, 
   imgProps = {} 
 }) {
   return (
     <ImageBase  
       {...imgProps}
-      {...{ sanityConfig, image, layoutClassName, imgProps }}
+      {...{ sanityConfig, image, sizes, layoutClassName, imgProps }}
       adjustImage={adjustImageWidthAndCrop(aspectRatio)}
       deriveSizes={deriveSizesCropped(aspectRatio)}
     />
@@ -39,12 +41,13 @@ export function ImageCover({
   sanityConfig,
   image,
   aspectRatio,
+  sizes = undefined,
   layoutClassName = undefined, 
   imgProps = {} 
 }) {
   return (
     <ImageBase  
-      {...{ sanityConfig, image, layoutClassName, imgProps }}
+      {...{ sanityConfig, image, sizes, layoutClassName, imgProps }}
       adjustImage={adjustImageWidthAndCrop(aspectRatio)}
       deriveSizes={deriveSizesCover(aspectRatio)}
       style={{
@@ -64,6 +67,7 @@ function ImageBase({
   image,
   adjustImage,
   deriveSizes,
+  sizes = undefined,
   style = {}, 
   imgProps = {}, 
   layoutClassName = undefined 
@@ -85,7 +89,7 @@ function ImageBase({
       {...imgProps}
       ref={sizeRef}
       className={layoutClassName}
-      sizes={size + 'px'}
+      sizes={sizes || `${size}px`}
       {...{ src, srcSet, width, height, style }}
     />
   )

--- a/src/Image.js
+++ b/src/Image.js
@@ -6,15 +6,14 @@ const SIZES = [320, 480, 720, 1024, 1440, 1920, 2400, 3000, 3600]
 export function Image({
   sanityConfig,
   image,
-  sizes = undefined,
-  layoutClassName = undefined,
-  imgProps = {}
+  layoutClassName = undefined, 
+  imgProps = {} 
 }) {
   return (
-    <ImageBase
+    <ImageBase  
       {...{ sanityConfig, image, layoutClassName, imgProps }}
       adjustImage={adjustImageWidth()}
-      deriveSizes={deriveSizes({ sizes })}
+      deriveSizes={deriveSizes()}
     />
   )
 }
@@ -23,16 +22,15 @@ export function ImageCropped({
   sanityConfig,
   image,
   aspectRatio,
-  sizes = undefined,
-  layoutClassName = undefined,
-  imgProps = {}
+  layoutClassName = undefined, 
+  imgProps = {} 
 }) {
   return (
-    <ImageBase
+    <ImageBase  
       {...imgProps}
       {...{ sanityConfig, image, layoutClassName, imgProps }}
       adjustImage={adjustImageWidthAndCrop(aspectRatio)}
-      deriveSizes={deriveSizesCropped({ aspectRatio, sizes })}
+      deriveSizes={deriveSizesCropped(aspectRatio)}
     />
   )
 }
@@ -41,21 +39,20 @@ export function ImageCover({
   sanityConfig,
   image,
   aspectRatio,
-  sizes = undefined,
-  layoutClassName = undefined,
-  imgProps = {}
+  layoutClassName = undefined, 
+  imgProps = {} 
 }) {
   return (
-    <ImageBase
+    <ImageBase  
       {...{ sanityConfig, image, layoutClassName, imgProps }}
       adjustImage={adjustImageWidthAndCrop(aspectRatio)}
-      deriveSizes={deriveSizesCover({ aspectRatio, sizes })}
+      deriveSizes={deriveSizesCover(aspectRatio)}
       style={{
         objectFit: 'cover',
-        ...image.hotspot && {
-          // Because our cropped image size may not match the actual display size,
+        ...image.hotspot && { 
+          // Because our cropped image size may not match the actual display size, 
           // it's useful to set the object-position the hotspot x and y values
-          objectPosition: `${image.hotspot.x * 100}% ${image.hotspot.y * 100}%`
+          objectPosition: `${image.hotspot.x * 100}% ${image.hotspot.y * 100}%` 
         }
       }}
     />
@@ -67,9 +64,9 @@ function ImageBase({
   image,
   adjustImage,
   deriveSizes,
-  style = {},
-  imgProps = {},
-  layoutClassName = undefined
+  style = {}, 
+  imgProps = {}, 
+  layoutClassName = undefined 
 }) {
   if (process.env.NODE_ENV !== 'production' && !image.asset.metadata) {
     console.error('Image asset doesn\'t have associated metadata. Did you forget to dereference the asset field (`image{..., asset->}`)?')
@@ -77,18 +74,19 @@ function ImageBase({
 
   const { ref: sizeRef, size: displaySize } = useElementSize()
   const { src, srcSet } = useSrcSet({ config: sanityConfig, image, adjustImage })
-  const { width, height, sizes } = useDerivedSizes({
-    deriveSizes,
+  const { width, height, size } = useDerivedSizes({
+    deriveSizes, 
     displaySize,
-    naturalSize: image.asset.metadata.dimensions
+    naturalSize: image.asset.metadata.dimensions  
   })
 
   return (
-    <img
+    <img 
       {...imgProps}
       ref={sizeRef}
       className={layoutClassName}
-      {...{ src, srcSet, sizes, width, height, style }}
+      sizes={size + 'px'}
+      {...{ src, srcSet, width, height, style }}
     />
   )
 }
@@ -131,7 +129,7 @@ function useDerivedSizes({ deriveSizes, naturalSize, displaySize }) {
   deriveSizesRef.current = deriveSizes
 
   return React.useMemo(
-    () => deriveSizesRef.current({ naturalSize, displaySize }),
+    () => deriveSizesRef.current({ naturalSize, displaySize }), 
     [naturalSize.width, naturalSize.height, displaySize.width, displaySize.height]
   )
 }
@@ -141,49 +139,37 @@ function adjustImageWidth() {
 }
 
 function adjustImageWidthAndCrop(aspectRatio) {
-  return (image, width) => image.width(width).height(Math.round(width / aspectRatio))
+  return (image, width) => image.width(width).height(Math.round(width / aspectRatio)) 
 }
 
-function deriveSizes({ sizes }) {
+function deriveSizes() {
   return ({ naturalSize, displaySize }) => ({
     width: naturalSize.width,
     height: naturalSize.height,
-    sizes: (
-      sizes ? sizes :
-      displaySize.width ? displaySize.width + 'px' :
-      '1px'
-    )
+    size: Math.max(1, displaySize.width)
   })
 }
 
-function deriveSizesCropped({ aspectRatio, sizes }) {
+function deriveSizesCropped(aspectRatio) {
   return ({ naturalSize, displaySize }) => ({
     width: naturalSize.width,
     height: naturalSize.width / aspectRatio,
-    sizes: (
-      sizes ? sizes :
-      displaySize.width ? displaySize.width + 'px' :
-      '1px'
-    )
+    size: Math.max(1, displaySize.width)
   })
 }
 
 // deriveSizesCover can return a sizes value larger than the actual display 
 // width in case the image is scaled up by object-fit
-function deriveSizesCover({ aspectRatio, sizes }) {
+function deriveSizesCover(aspectRatio) {
   return ({ naturalSize, displaySize }) => {
-    const size = (displaySize.width && displaySize.height)
+    const size = (displaySize.width && displaySize.height) 
       ? Math.max(displaySize.height * aspectRatio, displaySize.width)
       : 0
 
     return {
       width: naturalSize.width,
       height: naturalSize.width / aspectRatio,
-      sizes: (
-        sizes ? sizes :
-        size ? size + 'px' :
-        '1px'
-      )
+      size: Math.max(1, size)
     }
   }
 }

--- a/src/Image.js
+++ b/src/Image.js
@@ -76,6 +76,7 @@ function ImageBase({
     throw new Error('Image asset doesn\'t have associated metadata. Did you forget to dereference the asset field (`image{..., asset->}`)?')
   }
 
+  const className = [imgProps.className, layoutClassName].filter(Boolean).join(' ')
   const { ref: sizeRef, size: displaySize } = useElementSize()
   const { src, srcSet } = useSrcSet({ config: sanityConfig, image, adjustImage })
   const { width, height, size } = useDerivedSizes({
@@ -88,9 +89,8 @@ function ImageBase({
     <img 
       {...imgProps}
       ref={sizeRef}
-      className={layoutClassName}
       sizes={sizes || `${size}px`}
-      {...{ src, srcSet, width, height, style }}
+      {...{ className, src, srcSet, width, height, style }}
     />
   )
 }


### PR DESCRIPTION
Allow a sizes attribute to be given, overwriting the calculated image size.

This is useful for images that are displayed above the fold, giving you the opportunity to reduce LCP (last contentful paint)

@EECOLOR Ik zou het sizes attribuut ook aan het Base component mee kunnen geven, buiten de deriveXxx functies om. Ik twijfel even over wat beter is.