### PR TITLE
Add adjustImage to dependancy array

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@kaliber/sanity-image",
-  "version": "1.3.1",
+  "version": "1.3.2",
   "main": "index.js",
   "sideEffects": false,
   "publishConfig": {

--- a/src/Image.js
+++ b/src/Image.js
@@ -125,7 +125,7 @@ function useSrcSet({ config, image, adjustImage, width }) {
 
       return { src, srcSet, thumb: `${thumb.src} 1w` }
     },
-    [image, width, builder]
+    [image, width, builder, adjustImage]
   )
 }
 


### PR DESCRIPTION
Wanneer je op deze manier een aspect-ratio zet op een image:
```
  {image && onMounted && (
          <div className={styles.image}>
            <ImageCover aspectRatio={isViewportMd ? 3 / 4 : 16 / 9} {...{ image }} />
          </div>
        )}
```
initieel laad hij nu de juiste variant in maar wanneer je gaat scalen heeft hij nu nog een refresh nodig. Door de `adjustImage` aan de dependancy array toe te voegen los je dit volgens mij op.